### PR TITLE
Add virtual directory syntax

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1433,8 +1433,9 @@ key = directory tuple
 value = 'clear' | data
 
 (* Directories *)
-directory = ( '/' | '@' ) ( '<>' | name | string ) [ subdir ]
-subdir = '/' ( '<>' | name | string ) [ subdir ]
+directory = ( '/' | '@' ) segment [ subdir ]
+subdir = '/' segment [ subdir ]
+segment = '<>' | name | string
 
 (* Tuples *)
 tuple = '(' [ nl elements [ ',' ] nl ] ')'

--- a/docs/index.md
+++ b/docs/index.md
@@ -402,7 +402,8 @@ adjacently stored.
 [directory layer]: https://apple.github.io/foundationdb/developer-guide.html#directories
 
 ```ebnf {.grammar}
-directory = '/' element [ directory ]
+directory = ( '/' | '@' ) element [ subdir ]
+subdir = '/' element [ subdir ]
 element = '<>' | name | string
 ```
 
@@ -1432,7 +1433,8 @@ key = directory tuple
 value = 'clear' | data
 
 (* Directories *)
-directory = '/' ( '<>' | name | string ) [ directory ]
+directory = ( '/' | '@' ) ( '<>' | name | string ) [ subdir ]
+subdir = '/' ( '<>' | name | string ) [ subdir ]
 
 (* Tuples *)
 tuple = '(' [ nl elements [ ',' ] nl ] ')'

--- a/docs/index.md
+++ b/docs/index.md
@@ -402,9 +402,9 @@ adjacently stored.
 [directory layer]: https://apple.github.io/foundationdb/developer-guide.html#directories
 
 ```ebnf {.grammar}
-directory = ( '/' | '@' ) element [ subdir ]
-subdir = '/' element [ subdir ]
-element = '<>' | name | string
+directory = ( '/' | '@' ) segment [ subdir ]
+subdir = '/' segment [ subdir ]
+segment = '<>' | name | string
 ```
 
 A directory is specified as a sequence of strings, each

--- a/docs/js/fql.js
+++ b/docs/js/fql.js
@@ -291,7 +291,7 @@
 
   const DIRECTORY = {
     scope: 'directory',
-    begin: /\//,
+    begin: /[/@]/,
     end: /(?=[\(=\s]|$)/,
     contains: [
       STRING,

--- a/syntax.ebnf
+++ b/syntax.ebnf
@@ -13,7 +13,9 @@ key = directory tuple
 
 value = 'clear' | data
 
-directory = '/' ( '<>' | name | string ) [ directory ]
+directory = ( '/' | '@' ) ( '<>' | name | string ) [ subdir ]
+
+subdir = '/' ( '<>' | name | string ) [ subdir ]
 
 tuple = '(' [ nl elements [ ',' ] nl ] ')'
 

--- a/syntax.ebnf
+++ b/syntax.ebnf
@@ -13,9 +13,11 @@ key = directory tuple
 
 value = 'clear' | data
 
-directory = ( '/' | '@' ) ( '<>' | name | string ) [ subdir ]
+directory = ( '/' | '@' ) segment [ subdir ]
 
-subdir = '/' ( '<>' | name | string ) [ subdir ]
+subdir = '/' segment [ subdir ]
+
+segment = '<>' | name | string
 
 tuple = '(' [ nl elements [ ',' ] nl ] ')'
 


### PR DESCRIPTION
## Summary
- Allow a directory path to begin with `@` instead of `/` as a *virtual directory*; only the first component may be virtual, subsequent components still use `/`.
- Splits the EBNF `directory` rule into `directory` + `subdir` in `syntax.ebnf` and both grammar blocks in `docs/index.md`.
- Loosens the highlight.js `DIRECTORY` rule so `@` is recognized as a directory-starting separator.

## Test plan
- [ ] `./build.sh --docs` regenerates `docs/index.html` cleanly
- [ ] Visually confirm both EBNF blocks render with the new `subdir` rule
- [ ] Confirm `@cache/users/index` highlights with the same color as `/my/directory/path_way`

🤖 Generated with [Claude Code](https://claude.com/claude-code)